### PR TITLE
Voorstel aanpassing bij sort

### DIFF
--- a/modules/filters/030_filters_theory.md
+++ b/modules/filters/030_filters_theory.md
@@ -244,6 +244,8 @@ Queen
 
 But the `sort` filter has many options to tweak its usage. This example shows sorting different columns (column 1 or column 2).
 
+Option ``-t`` specifies the delimiter character.
+
 ```console
 [student@linux pipes]$ sort -k1 -t, country.txt 
 Belgium,Brussels,10

--- a/modules/filters/030_filters_theory.md
+++ b/modules/filters/030_filters_theory.md
@@ -245,13 +245,13 @@ Queen
 But the `sort` filter has many options to tweak its usage. This example shows sorting different columns (column 1 or column 2).
 
 ```console
-[student@linux pipes]$ sort -k1 country.txt 
+[student@linux pipes]$ sort -k1 -t, country.txt 
 Belgium,Brussels,10
 France,Paris,60
 Germany,Berlin,100
 Iran,Teheran,70
 Italy,Rome,50
-[student@linux pipes]$ sort -k2 country.txt 
+[student@linux pipes]$ sort -k2 -t, country.txt 
 Germany,Berlin,100
 Belgium,Brussels,10
 France,Paris,60
@@ -262,13 +262,13 @@ Iran,Teheran,70
 The screenshot below shows the difference between an alphabetical sort and a numerical sort (both on the third column).
 
 ```console
-[student@linux pipes]$ sort -k3 country.txt 
+[student@linux pipes]$ sort -k3 -t, country.txt 
 Belgium,Brussels,10
 Germany,Berlin,100
 Italy,Rome,50
 France,Paris,60
 Iran,Teheran,70
-[student@linux pipes]$ sort -n -k3 country.txt 
+[student@linux pipes]$ sort -n -k3 -t, country.txt 
 Belgium,Brussels,10
 Italy,Rome,50
 France,Paris,60


### PR DESCRIPTION
Sort gebruikt bij default spaties en tabs als delimiter. Dit wordt niet expliciet getoond in het voorbeeld wat voor verwarring kan zorgen. Het voorbeeld bevat nu de flag -t, om dit duidelijk aan te geven.